### PR TITLE
Fix ex-bins/simple loading on radeco

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -130,6 +130,17 @@ impl Token {
         }
     }
 
+    pub fn is_meta(&self) -> bool {
+        match *self {
+            Token::EOld |
+            Token::EOld_ |
+            Token::ECur |
+            Token::ELastsz |
+            Token::EAddress => true,
+            _ => false,
+        }
+    }
+
     pub fn should_set_vars(&self) -> bool {
         match *self {
             Token::ECmp | Token::EEq | Token::EPoke(_) | Token::EGt | Token::ELt => true,


### PR DESCRIPTION
Hi,
Here's a fix for parse's panic when loading radeco/ex-bins/simple. I'm not entirely sure whether this is correct because parser`s logic is still a bit obscure to me. So please let me know if something should be changed!
Commit's message should give some context about how to reproduce this bug.