### PR TITLE
The parser should not panic

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+
+[package]
+name = "esil-fuzz"
+version = "0.0.1"
+authors = ["Radeco Developers"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.esil]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "parser"
+path = "fuzzers/parser.rs"

--- a/fuzz/fuzzers/parser.rs
+++ b/fuzz/fuzzers/parser.rs
@@ -1,0 +1,34 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate esil;
+
+use std::collections::HashMap;
+use std::str;
+
+use esil::parser::{Parse, Parser};
+use esil::lexer::{Token, Tokenizer};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(esil) = str::from_utf8(data) {
+        let regset: HashMap<String, u64>  = {
+            let mut regset = HashMap::new();
+            regset.insert("rax".to_owned(), 64);
+            regset.insert("rbx".to_owned(), 64);
+            regset.insert("rcx".to_owned(), 64);
+            regset.insert("eax".to_owned(), 32);
+            regset.insert("ebx".to_owned(), 32);
+            regset.insert("ecx".to_owned(), 32);
+            regset.insert("zf".to_owned(), 1);
+            regset.insert("pf".to_owned(), 1);
+            regset.insert("cf".to_owned(), 1);
+            regset.insert("of".to_owned(), 1);
+            regset.insert("sf".to_owned(), 1);
+            regset
+        };
+        let mut parser = Parser::init(Some(regset), Some(64));
+        parser.lastsz = Some(Token::EConstant(64));
+        while let Ok(Some(ref token)) = parser.parse::<_, Tokenizer>(esil) {
+            let _ = parser.fetch_operands(token);
+        }
+    }
+});

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -415,7 +415,7 @@ impl Tokenize for Tokenizer {
                                 }
                             }
                         } else if t.starts_with("0x") {
-                            match u64::from_str_radix(t.trim_left_matches("0x"), 16) {
+                            match u64::from_str_radix(t.trim_start_matches("0x"), 16) {
                                 Ok(v) => vec![Token::EConstant(v)],
                                 Err(_) => vec![Token::EInvalid],
                             }


### PR DESCRIPTION
## Update parser to not `panic!`

The `Parser` currently `panic`s when it hits something that
is not expected. It should instead return a `Result` where
the caller can determine if a `panic` is the correct response.

## Add a fuzz target

Add a `cargo-fuzz` target

Fixes: #7 